### PR TITLE
fix: remove redundant activity status check in admin API

### DIFF
--- a/services/api-service/app/api/v1/admin/lucky-number.js
+++ b/services/api-service/app/api/v1/admin/lucky-number.js
@@ -82,10 +82,6 @@ router.get(
             throw BAD_REQUEST('活动不存在');
         }
 
-        if (activity.status !== LUCKY_NUMBER_STATUS.ONGOING) {
-            throw BAD_REQUEST('活动未开始或已结束');
-        }
-
         const summary = await UserParticipationDao.getActivitySummary(
             activity.id,
         );


### PR DESCRIPTION
## Type 🏷️
- [x] 🐛 Bug Fix

## Scope 📦
- [x] @ying-web/api-service

## Changes 📝

### What's New
- Removed redundant activity status check in admin lucky number query API
- Allows administrators to view activity details regardless of its status (not_started/ongoing/ended)

### Breaking Changes
None

## Testing 🧪
- Verified admin can query activity details in all status
- Confirmed user-facing API still maintains status validation
- Tested activity summary data retrieval

## Checklist ✅
- [x] Tests added/updated
- [x] Documentation updated
- [x] Self-reviewed
- [x] No console.logs/debugging code
- [x] Tested in supported browsers

## Related Issues 🔗
N/A