### PR TITLE
refactor: split lucky number query api and optimize data fetching

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -29,6 +29,7 @@
         "lodash": "^4.17.21",
         "lucide-react": "^0.424.0",
         "react": "^18.3.1",
+        "react-csv": "^2.2.2",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.22.3"
     },
@@ -39,6 +40,7 @@
         "@types/lodash": "^4.17.1",
         "@types/node": "^20.17.6",
         "@types/react": "^18.3.5",
+        "@types/react-csv": "^1.1.10",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",

--- a/apps/admin/src/hooks/useLuckyNumber.ts
+++ b/apps/admin/src/hooks/useLuckyNumber.ts
@@ -3,13 +3,14 @@ import { useCallback, useState } from 'react';
 import axiosInstance from '@/services/axios';
 import type { Pagination } from '@/types';
 import type {
+    ActivityInfo,
     CancelParticipationLuckyNumberRequest,
     CancelParticipationLuckyNumberResponse,
     CreateLuckyNumberRequest,
     CreateLuckyNumberResponse,
     DeleteLuckyNumberResponse,
+    LuckyNumber,
     QueryLuckyNumberListResponse,
-    QueryLuckyNumberResponse,
 } from '@/types/luckyNumber';
 
 export const useLuckyNumber = () => {
@@ -61,22 +62,35 @@ export const useLuckyNumber = () => {
         [],
     );
 
-    const queryActivity = useCallback(async (key: string) => {
-        setLoading(true);
-        setError(null);
-        try {
-            const response = await axiosInstance.get<QueryLuckyNumberResponse>(
-                `/lucky-number/query/${key}`,
-            );
-            const { data } = response ?? {};
-            return data;
-        } catch (err) {
-            setError('查询活动失败');
-            throw err;
-        } finally {
-            setLoading(false);
-        }
-    }, []);
+    const queryActivity = useCallback(
+        async (key: string, pageNum = 1, pageSize = 10) => {
+            setLoading(true);
+            setError(null);
+            try {
+                const response = await axiosInstance.get<
+                    {},
+                    {
+                        data: LuckyNumber[];
+                        pagination: Pagination;
+                    }
+                >(
+                    `/lucky-number/query/${key}?page_num=${pageNum}&page_size=${pageSize}`,
+                );
+
+                const { data, pagination } = response ?? {};
+                return {
+                    list: data,
+                    pagination,
+                };
+            } catch (err) {
+                setError('查询活动失败');
+                throw err;
+            } finally {
+                setLoading(false);
+            }
+        },
+        [],
+    );
 
     const deleteActivity = useCallback(async (key: string) => {
         setLoading(true);
@@ -145,6 +159,45 @@ export const useLuckyNumber = () => {
         [],
     );
 
+    const getActivityInfo = useCallback(async (key: string) => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await axiosInstance.get<ActivityInfo>(
+                `/lucky-number/info/${key}`,
+            );
+            const { data } = response ?? {};
+            return data;
+        } catch (err) {
+            setError('获取活动详情失败');
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    const getAllParticipations = useCallback(async (key: string) => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await axiosInstance.get<
+                {},
+                {
+                    data: LuckyNumber[];
+                    pagination: Pagination;
+                }
+            >(`/lucky-number/query/${key}?page_num=1&page_size=999999`);
+
+            const { data } = response ?? {};
+            return data;
+        } catch (err) {
+            setError('获取所有参与记录失败');
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
     return {
         createActivity,
         queryActivity,
@@ -152,6 +205,8 @@ export const useLuckyNumber = () => {
         cancelParticipation,
         getActivityList,
         updateActivityStatus,
+        getActivityInfo,
+        getAllParticipations,
         loading,
         error,
     };

--- a/apps/admin/src/types/luckyNumber.ts
+++ b/apps/admin/src/types/luckyNumber.ts
@@ -18,7 +18,7 @@ export interface CreateLuckyNumberResponse {
 export interface LuckyNumber {
     drawn_number: number;
     username: string | null;
-    drawn_at: string | null;
+    created_at: string | null;
 }
 
 export interface QueryLuckyNumberResponse {
@@ -31,7 +31,7 @@ export interface QueryLuckyNumberResponse {
     participations: {
         drawn_number: number;
         username: string;
-        drawn_at: string;
+        created_at: string;
     }[];
     statistics: {
         total_participants: number;
@@ -74,4 +74,14 @@ export interface CancelParticipationLuckyNumberResponse {
     message: string;
     username: string;
     drawn_number: number;
+}
+
+export interface ActivityInfo {
+    id: number;
+    activity_key: string;
+    name: string;
+    description: string;
+    participant_limit: number;
+    status: LuckyNumberStatus;
+    count: number;
 }

--- a/apps/admin/src/utils/constants.ts
+++ b/apps/admin/src/utils/constants.ts
@@ -13,8 +13,10 @@ export const LUCKY_NUMBER_STATUS_MAP = Object.freeze({
     [LUCKY_NUMBER_STATUS.ENDED]: '已结束',
 });
 
-export const getLuckyNumberStatusLabel = (status: LuckyNumberStatus) => {
-    return LUCKY_NUMBER_STATUS_MAP[status];
+export const getLuckyNumberStatusLabel = (
+    status: LuckyNumberStatus | undefined,
+) => {
+    return status ? LUCKY_NUMBER_STATUS_MAP[status] : '';
 };
 
 export const KEYS = Object.freeze({

--- a/apps/events/src/hooks/useLuckyNumber.ts
+++ b/apps/events/src/hooks/useLuckyNumber.ts
@@ -2,9 +2,10 @@ import { useCallback, useState } from 'react';
 
 import axiosInstance from '@/services/axios';
 import type {
+    ActivityInfo,
     DrawLuckyNumberRequest,
     DrawLuckyNumberResponse,
-    QueryLuckyNumberResponse,
+    LuckyNumber,
 } from '@/types/luckyNumber';
 
 export const useLuckyNumber = () => {
@@ -20,12 +21,33 @@ export const useLuckyNumber = () => {
         setLoading(true);
 
         try {
-            const response = await axiosInstance.get<QueryLuckyNumberResponse>(
-                `/lucky-number/query/${activityKey}`,
+            const response = await axiosInstance.get<ActivityInfo>(
+                `/lucky-number/info/${activityKey}`,
             );
             return response.data;
         } catch (err) {
             setError('获取活动信息失败');
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    const queryParticipations = useCallback(async (activityKey?: string) => {
+        setError(null);
+        if (!activityKey) {
+            setError('活动key不能为空');
+            throw new Error('活动key不能为空');
+        }
+        setLoading(true);
+
+        try {
+            const response = await axiosInstance.get<LuckyNumber[]>(
+                `/lucky-number/query/${activityKey}?page=1&page_size=10000`,
+            );
+            return response.data;
+        } catch (err) {
+            setError('获取参与记录失败');
             throw err;
         } finally {
             setLoading(false);
@@ -58,6 +80,7 @@ export const useLuckyNumber = () => {
         loading,
         error,
         queryActivityInfo,
+        queryParticipations,
         drawLuckyNumber,
     };
 };

--- a/apps/events/src/types/luckyNumber.ts
+++ b/apps/events/src/types/luckyNumber.ts
@@ -5,6 +5,7 @@ export interface LuckyNumber {
     id: number;
     drawn_number: number;
     username: string | null;
+    created_at: string | null;
 }
 
 export interface QueryLuckyNumberResponse {
@@ -43,4 +44,16 @@ export interface DrawLuckyNumberRequest {
 
 export interface DrawLuckyNumberResponse {
     drawn_number: number;
+    message: string;
+}
+
+// GET /api/v1/admin/lucky-number/info/:key
+export interface ActivityInfo {
+    id: number;
+    activity_key: string;
+    name: string;
+    description: string;
+    participant_limit: number;
+    status: LuckyNumberStatus;
+    count: number;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
+      react-csv:
+        specifier: ^2.2.2
+        version: 2.2.2
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -106,6 +109,9 @@ importers:
       '@types/react':
         specifier: ^18.3.5
         version: 18.3.12
+      '@types/react-csv':
+        specifier: ^1.1.10
+        version: 1.1.10
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.1
@@ -422,10 +428,10 @@ importers:
         version: 9.1.0(eslint@9.15.0(jiti@1.21.6))
       eslint-import-resolver-typescript:
         specifier: ^3.6.3
-        version: 3.6.3(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@1.21.6))
+        version: 3.6.3(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@1.21.6))
       eslint-plugin-import:
         specifier: ^2.30.0
-        version: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
+        version: 2.31.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
       eslint-plugin-prettier:
         specifier: ^5.1.3
         version: 5.2.1(@types/eslint@8.56.12)(eslint-config-prettier@9.1.0(eslint@9.15.0(jiti@1.21.6)))(eslint@9.15.0(jiti@1.21.6))(prettier@3.3.3)
@@ -3346,6 +3352,9 @@ packages:
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/react-csv@1.1.10':
+    resolution: {integrity: sha512-PESAyASL7Nfi/IyBR3ufd8qZkyoS+7jOylKmJxRZUZLFASLo4NZaRsJ8rNP8pCcbIziADyWBbLPD1nPddhsL4g==}
 
   '@types/react-dom@18.3.1':
     resolution: {integrity: sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==}
@@ -8951,6 +8960,9 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-csv@2.2.2:
+    resolution: {integrity: sha512-RG5hOcZKZFigIGE8LxIEV/OgS1vigFQT4EkaHeKgyuCbUAu9Nbd/1RYq++bJcJJ9VOqO/n9TZRADsXNDR4VEpw==}
+
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -13683,6 +13695,10 @@ snapshots:
 
   '@types/range-parser@1.2.7': {}
 
+  '@types/react-csv@1.1.10':
+    dependencies:
+      '@types/react': 18.3.12
+
   '@types/react-dom@18.3.1':
     dependencies:
       '@types/react': 18.3.12
@@ -16039,19 +16055,19 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@1.21.6)):
+  eslint-import-resolver-typescript@3.6.3(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@1.21.6)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.15.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -16069,14 +16085,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7(supports-color@5.5.0)
     optionalDependencies:
-      '@typescript-eslint/parser': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4)
       eslint: 9.15.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4))(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@1.21.6))
+      eslint-import-resolver-typescript: 3.6.3(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@1.21.6))
     transitivePeerDependencies:
       - supports-color
 
@@ -16109,7 +16124,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6)):
+  eslint-plugin-import@2.31.0(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -16120,7 +16135,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.15.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -16131,8 +16146,6 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.15.0(eslint@9.15.0(jiti@1.21.6))(typescript@5.5.4)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -20702,6 +20715,8 @@ snapshots:
     dependencies:
       react: 18.3.1
       tween-functions: 1.2.0
+
+  react-csv@2.2.2: {}
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:

--- a/services/api-service/app/dao/lucky-number/number-pool.js
+++ b/services/api-service/app/dao/lucky-number/number-pool.js
@@ -31,4 +31,13 @@ export class NumberPoolDao {
             throw INTERNAL_SERVER_ERROR('查询可用幸运号码失败');
         }
     }
+
+    static async getCount(activityId) {
+        const res = await NumberPoolModel.count({
+            where: {
+                activity_id: activityId,
+            },
+        });
+        return res;
+    }
 }

--- a/services/api-service/app/dao/lucky-number/user-participation.js
+++ b/services/api-service/app/dao/lucky-number/user-participation.js
@@ -99,4 +99,57 @@ export class UserParticipationDao {
             })),
         };
     }
+
+    static async query({
+        page_num = 1,
+        page_size = 10,
+        activity_id,
+        username,
+        drawn_number,
+        order = 'DESC',
+    }) {
+        try {
+            const whereQuery = {
+                deleted_at: null,
+            };
+            if (activity_id) {
+                whereQuery.activity_id = activity_id;
+            }
+            if (username) {
+                whereQuery.username = {
+                    [Op.like]: `%${username}%`,
+                };
+            }
+            if (drawn_number) {
+                whereQuery.drawn_number = {
+                    [Op.like]: `%${drawn_number}%`,
+                };
+            }
+
+            const result = await UserParticipationModel.findAndCountAll({
+                attributes: [
+                    'id',
+                    'activity_id',
+                    'username',
+                    'drawn_number',
+                    'created_at',
+                ],
+                where: whereQuery,
+                offset: (page_num - 1) * page_size,
+                limit: page_size,
+                order: [['id', order]],
+            });
+            return {
+                data: result.rows,
+                pagination: {
+                    count: page_num,
+                    size: page_size,
+                    total: result.count,
+                },
+            };
+        } catch (error) {
+            log.error(error);
+            throw INTERNAL_SERVER_ERROR('查询用户参与记录失败');
+        }
+    }
 }

--- a/services/api-service/app/middlewares/validators/lucky-number.js
+++ b/services/api-service/app/middlewares/validators/lucky-number.js
@@ -12,18 +12,31 @@ export const createLuckyNumberValidatorMiddleware = createValidator({
     ],
 });
 
-export const queryLuckyNumberValidatorMiddleware = createValidator(
+export const luckyNumberKeyValidatorMiddleware = createValidator(
     {
         key: [{ type: 'string', required: true, message: '活动标识是必需的' }],
     },
     'params',
 );
 
-export const deleteLuckyNumberValidatorMiddleware = createValidator(
+export const queryLuckyNumberValidatorMiddleware = createValidator(
     {
-        key: [{ type: 'string', required: true, message: '活动标识是必需的' }],
+        page_num: [
+            {
+                type: 'string',
+                message: '请输入正确的页码',
+                pattern: /^\d+$/,
+            },
+        ],
+        page_size: [
+            {
+                type: 'string',
+                message: '请输入正确的页大小',
+                pattern: /^\d+$/,
+            },
+        ],
     },
-    'params',
+    'query',
 );
 
 export const cancelParticipatedLuckyNumberValidatorMiddleware = createValidator(


### PR DESCRIPTION
## Type 🏷️
- [x] 🛠️ Refactor

## Scope 📦
- [x] @ying-web/api-service
- [x] @ying-web/events

## Changes 📝

### What's New
- Split lucky number query API into separate info and query endpoints
- Optimize frontend data fetching logic to reduce unnecessary requests
- Update TypeScript interfaces to match new API structure

### Breaking Changes
- Modified `/lucky-number/query/:key` response structure
- Added new `/lucky-number/info/:key` endpoint

## Testing 🧪
- Tested activity list page data display
- Verified real-time updates for activity info and participation records

## Checklist ✅
- [x] Tests added/updated
- [x] Documentation updated
- [x] Self-reviewed
- [x] No console.logs/debugging code
- [x] Tested in supported browsers