### PR TITLE
fix(api-service): resolve infinite recursion in performance cache monitoring

### DIFF
--- a/services/api-service/app/middlewares/performance.js
+++ b/services/api-service/app/middlewares/performance.js
@@ -51,12 +51,14 @@ const performanceMiddleware = async (ctx, next) => {
     const startDbQueries = performanceData.dbQueryCount;
 
     // Monitor cache operations
-    const originalCacheGet = ctx.cache?.get;
-    const originalCacheSet = ctx.cache?.set;
+    // Store original methods bound to the cache instance to avoid circular references
+    const originalCacheGet = ctx.cache?.get?.bind(ctx.cache);
+    const originalCacheSet = ctx.cache?.set?.bind(ctx.cache);
 
-    if (ctx.cache) {
+    if (ctx.cache && originalCacheGet && originalCacheSet) {
+        // Wrap get method to track cache hits/misses
         ctx.cache.get = async function (key) {
-            const result = await originalCacheGet.call(this, key);
+            const result = await originalCacheGet(key);
             if (result !== undefined) {
                 performanceData.cacheHits++;
             } else {
@@ -65,12 +67,21 @@ const performanceMiddleware = async (ctx, next) => {
             return result;
         };
 
+        // Wrap set method (currently just passes through)
         ctx.cache.set = async function (key, value, ttl) {
-            return await originalCacheSet.call(this, key, value, ttl);
+            return await originalCacheSet(key, value, ttl);
         };
     }
 
-    await next();
+    try {
+        await next();
+    } finally {
+        // Restore original cache methods to prevent memory leaks
+        if (ctx.cache && originalCacheGet && originalCacheSet) {
+            ctx.cache.get = originalCacheGet;
+            ctx.cache.set = originalCacheSet;
+        }
+    }
 
     const responseTime = Date.now() - startTime;
     const dbQueriesInRequest = performanceData.dbQueryCount - startDbQueries;


### PR DESCRIPTION
…itoring

<!--
🙏 Thank you for contributing to @ying-web!
Please make sure your code follows our standards and includes necessary tests/docs.
-->

## Type 🏷️

<!-- Check one with "x" -->

-   [ ] 🐛 Bug Fix
-   [ ] ✨ New Feature
-   [ ] 📝 Documentation
-   [ ] 🔄 Dependency Update
-   [ ] 🎨 Style/UI
-   [ ] 🛠️ Refactor

## Scope 📦

<!-- Check affected projects -->

-   [ ] @ying-web/api-service
-   [ ] @ying-web/events
-   [ ] @ying-web/admin
-   [ ] @ying-web/tools
-   [ ] @ying-web/test-config
-   [ ] @ying-web/eslint-config

## Changes 📝

<!-- Describe your changes -->

### What's New

-

### Breaking Changes

-

## Testing 🧪

<!-- How have you tested this? -->

## Screenshots 📸

<!-- If applicable -->

## Related Issues 🔗

<!-- e.g., Fixes #123 -->

## Checklist ✅

-   [ ] Tests added/updated
-   [ ] Documentation updated
-   [ ] Self-reviewed
-   [ ] No console.logs/debugging code
-   [ ] Tested in supported browsers

<!--
💡 Tips:
- Keep changes focused
- Test thoroughly
- Update docs as needed
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Safely wraps and restores `ctx.cache.get/set` to prevent recursive calls and leaks while tracking cache hits/misses.
> 
> - **Performance middleware (`services/api-service/app/middlewares/performance.js`)**:
>   - Bind original `ctx.cache.get/set` to the cache instance and wrap `get` to record hits/misses; call bound methods directly (no `.call`).
>   - Add guards to ensure methods exist and use `try/finally` to always restore original methods after `await next()`.
>   - Keep `set` as pass-through; existing performance metrics and logging remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9bce702c5167772abb3a187d122f6be710e8329. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->